### PR TITLE
Refactored tests to enable overriding in private repos

### DIFF
--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql
@@ -5,6 +5,17 @@
                                                    group_by=None,
                                                    step=None) %}
 
+{{ adapter.dispatch('test_expect_column_values_to_be_decreasing', 'dbt_expectations')(model, column_name, 
+                                                                                        sort_column, 
+                                                                                        strictly, 
+                                                                                        row_condition, 
+                                                                                        group_by, 
+                                                                                        step) }}
+{% endtest %}
+
+{% macro default__test_expect_column_values_to_be_decreasing(model, column_name, sort_column, strictly, row_condition, group_by, step) %}
+
+
 {%- set sort_column = column_name if not sort_column else sort_column -%}
 {%- set operator = "<" if strictly else "<=" %}
 {%- set partition_by = group_by | join(", ") if group_by else "" -%}
@@ -40,8 +51,7 @@ validation_errors as (
     from
         add_lag_values
     where
-        value_field_lag is not null 
-        {% if target.type == 'clickhouse' -%}and value_field_lag <> 0 -- clickhouse will return data type default value which is not NULL and to get NULL we would need to know the data type of the value column to set the default to NULL, therefor this ugly hack {%- endif %}
+        value_field_lag is not null         
         and
         not (
             (value_field {{ operator }} value_field_lag)
@@ -53,5 +63,4 @@ validation_errors as (
 )
 select *
 from validation_errors
-{% endtest %}
-
+{% endmacro %}

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_increasing.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_increasing.sql
@@ -5,6 +5,17 @@
                                                    group_by=None,
                                                    step=None) %}
 
+{{ adapter.dispatch('test_expect_column_values_to_be_increasing', 'dbt_expectations')(model, column_name, 
+                                                                                        sort_column, 
+                                                                                        strictly, 
+                                                                                        row_condition, 
+                                                                                        group_by, 
+                                                                                        step) }}
+
+{% endtest %}
+
+{% macro default__test_expect_column_values_to_be_increasing(model, column_name, sort_column, strictly, row_condition, group_by, step) %}
+
 {%- set sort_column = column_name if not sort_column else sort_column -%}
 {%- set operator = ">" if strictly else ">=" -%}
 {%- set partition_by = group_by | join(", ") if group_by else "" -%}
@@ -54,4 +65,4 @@ validation_errors as (
 )
 select *
 from validation_errors
-{% endtest %}
+{% endmacro %}

--- a/macros/utils/lag.sql
+++ b/macros/utils/lag.sql
@@ -12,15 +12,3 @@
   lag({{ value_field }} {{ offset_clause }} {{ default_value_clause }}) over({{ partition_by_clause }} {{ order_by_clause }} {{ window_definition_clause }})
 
 {%- endmacro -%}
-
-
-{%- macro clickhouse__lag(value_field, offset, default_value, partition_by, order_by, window_definition) -%}
-{%- set partition_by_clause = "partition by " ~ partition_by if partition_by else "" -%}
-{%- set order_by_clause = "order by " ~ order_by if order_by else "" -%}
-{%- set window_definition_clause = window_definition if window_definition else "rows between unbounded preceding and unbounded following" -%}
-{%- set offset_clause = ", " ~ offset if offset else "" -%}
-{%- set default_value_clause = ", " ~ default_value if default_value else "" -%}
-
-  lagInFrame({{ value_field }} {{ offset_clause }} {{ default_value_clause }}) over({{ partition_by_clause }} {{ order_by_clause }} {{ window_definition_clause }})
-
-{%- endmacro -%}


### PR DESCRIPTION
## Summary of Changes

Tests for checking increasing / decreasing values were refactored to enable overriding and _lag_ macro was added to enable only overriding lag function in projects working with dialects which do not support standard _lag_ function (e.g. ClickHouse).
All ClickHouse specific code was removed from this PR.

## Why Do We Need These Changes
    
To enable overriding _lag_ function for dialects which do not support standard _lag_ function.

